### PR TITLE
Inserting healthcheck on mysql container

### DIFF
--- a/scripts/db/Dockerfile
+++ b/scripts/db/Dockerfile
@@ -13,3 +13,6 @@ COPY scripts/db/config.sql /docker-entrypoint-initdb.d
 COPY scripts/db/dump.sql /docker-entrypoint-initdb.d
 
 EXPOSE 3306
+
+HEALTHCHECK --interval=2m --timeout=5s \
+	CMD mysql -D$MYSQL_DATABASE -u$MYSQL_USER -p$MYSQL_PASSWORD -e '\q' || exit 1


### PR DESCRIPTION
Travis build was failing because tests were executed before mysql container was up and running, breaking the tests.